### PR TITLE
Finish frontend and backend for like/unlike posts

### DIFF
--- a/client/src/components/ImageCard.tsx
+++ b/client/src/components/ImageCard.tsx
@@ -1,10 +1,52 @@
 import { ImageData } from "../types";
+import Box from "@mui/material/Box";
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import Typography from "@mui/material/Typography";
+import axios from "axios";
+import {selectUserData, setImages} from "../slices/userSlice";
+import {useDispatch, useSelector} from "react-redux";
+
 
 export default function ImageCard({ imageData }: { imageData: ImageData }) {
-    
+    const dispatch = useDispatch();
+    const {userId} = useSelector(selectUserData);
+
+    const handleLike = async (postId: string, userId: string) => {
+        if (imageData.likes.includes(userId)) {
+            try {
+                const res = await axios.delete(
+                    `http://localhost:5000/api/posts/${postId}/likes/${userId}`,
+                );
+                dispatch(setImages(res.data.data));
+            } catch (err: any) {
+                console.log("Error unliking post.")
+            }
+        } else {
+            try {
+                const res = await axios.put(
+                    `http://localhost:5000/api/posts/${postId}/likes/${userId}`,
+                );
+                dispatch(setImages(res.data.data));
+
+            } catch (err: any) {
+                console.log("Error liking post.")
+            }
+        }
+    }
+
     return (
         <div className="card w-auto bg-base-100 shadow-xl">
             <figure><img src={imageData.url}  alt={imageData.id}/></figure>
+            <Box sx={{paddingTop: 5, paddingLeft: 5, display: 'flex',}}>
+
+                {imageData.likes.includes(userId) ? <FavoriteIcon fontSize="large" style={{ color: 'rgb(255,0,0)' }}
+                                                                  onClick={() =>handleLike(imageData.id,userId)}/>
+                    : <FavoriteBorderIcon fontSize="large" sx={{ "&:hover": { color: "gray"} }}
+                                          onClick={() => handleLike(imageData.id,userId)}/>}
+            </Box>
+            <Typography align="left" sx={{paddingTop: 1, paddingLeft: 6}}>{imageData.likes.length}
+                {imageData.likes.length === 1 ? " like" : " likes"} </Typography>
             <div className="card-body">
                 <p>{imageData.description}</p>
             </div>

--- a/client/src/pages/Homepage.tsx
+++ b/client/src/pages/Homepage.tsx
@@ -4,7 +4,7 @@ import ImageCard from "../components/ImageCard";
 import { useEffect, useState } from "react";
 import TabMenu from "../components/TabMenu";
 import {
-    selectUserData, setAuthToken
+    selectUserData, setAuthToken, setUserId
 } from "../slices/userSlice"
 import { UserDetails } from "../types";
 import { useDispatch, useSelector } from "react-redux";
@@ -37,9 +37,11 @@ const Homepage = () => {
 
             try {
                 const response = await fetchUserData(authToken);
-                const { username, images } = response.data;
+                const { username, _id, images } = response.data;
+                console.log("THIS IS UUID" + _id)
 
                 dispatch(setUsername(username));
+                dispatch(setUserId(_id));
                 dispatch(setImages(images));
             } catch (err) {
                 console.log(err);
@@ -52,7 +54,7 @@ const Homepage = () => {
 
     const userData: UserDetails = useSelector(selectUserData);
 
-    const { images, username, userBio, profileImageUrl } = userData;
+    const { images, username, userBio, profileImageUrl} = userData;
     const [option, setOption] = useState(0);
 
     const optionChange = (_event: any, selected: number) => {

--- a/client/src/pages/Homepage.tsx
+++ b/client/src/pages/Homepage.tsx
@@ -38,8 +38,6 @@ const Homepage = () => {
             try {
                 const response = await fetchUserData(authToken);
                 const { username, _id, images } = response.data;
-                console.log("THIS IS UUID" + _id)
-
                 dispatch(setUsername(username));
                 dispatch(setUserId(_id));
                 dispatch(setImages(images));

--- a/client/src/slices/userSlice.tsx
+++ b/client/src/slices/userSlice.tsx
@@ -19,6 +19,7 @@ export const userSlice = createSlice({
         error: undefined,
         userData: {
             username: '',
+            userId: '',
             userBio: userBio,
             profileImageUrl: profileImageUrl,
             images: images,
@@ -38,6 +39,9 @@ export const userSlice = createSlice({
         setUsername(state, action) {
             state.userData.username = action.payload;
         },
+        setUserId(state, action) {
+            state.userData.userId = action.payload;
+        },
 
         updateUserBio(state, action) {
             state.userData.userBio = action.payload;
@@ -46,17 +50,16 @@ export const userSlice = createSlice({
             state.authToken = action.payload;
         },
     },
-    
+
     extraReducers(builder) {
         /* TODO: state changes related to async thunk calls */
     }
 
 });
 
-export const { addImage, removeImage, updateUserBio, setUsername, setImages, setAuthToken} = userSlice.actions;
+export const { addImage, removeImage, updateUserBio, setUsername, setImages, setAuthToken,setUserId} = userSlice.actions;
 export const selectUserData = (state: any) => state.user.userData;
 export const selectAuthToken = (state: any) => state.user.authToken;
 export const selectIsLoadingUserData = (state: any) => state.user.loading;
 export const selectIsUserDataRetrieved = (state: any) => state.user.isUserDataRetrieved;
 export default userSlice.reducer;
-

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -2,10 +2,12 @@ export interface ImageData {
   id: string;
   url: string;
   description: string;
+  likes: any;
 }
 
 export interface UserDetails {
   username: string;
+  userId: string;
   userBio: string;
   profileImageUrl: string;
   images: ImageData[];

--- a/server/controllers/authControllers.ts
+++ b/server/controllers/authControllers.ts
@@ -45,7 +45,6 @@ export const registerUser = async (req: Request, res: Response) => {
  */
 
 export const loginUser = async (req: Request, res: Response) => {
-    console.log(req.body)
     const {usernameOrEmail, password} = req.body;
     try {
         const user = await User.login(usernameOrEmail, password);

--- a/server/controllers/imageController.ts
+++ b/server/controllers/imageController.ts
@@ -39,6 +39,7 @@ export const uploadImage = async (req: Request, res: Response) => {
               url: publicUrl,
               description:
                 "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
+              likes:[]
             },
           },
         }
@@ -67,3 +68,83 @@ export const uploadImage = async (req: Request, res: Response) => {
     });
   }
 };
+
+/**
+ * @param Expected request body: None, request url parameters: id of user who liked the post, id of liked post
+ *
+ * * @param Responds Responds with a success message, along with the updated image data or an error.
+ */
+
+export const likePost = async (req: Request, res: Response) => {
+  const {postid, userid} = req.params;
+  let result;
+
+  try {
+    result = await User.findOneAndUpdate({
+          "images.id": postid
+        },
+        {
+          $addToSet: {
+            "images.$[images].likes": userid
+          }
+        },
+        {
+          arrayFilters: [
+            {
+              "images.id": postid
+            }
+          ], new: true
+        })
+  } catch (err) {
+    return res.status(400).json({
+      message: "Error liking post",
+      error: err,
+    });
+  }
+
+  return res.status(200).json({
+    message: "Successfully liked post",
+    data: result.images,
+  });
+
+}
+
+/**
+ * @param Expected request body: None, request url parameters: id of user who unliked the post, id of unliked post
+ *
+ * * @param Responds Responds with a success message, along with the updated image data or an error.
+ */
+
+export const unlikePost = async (req: Request, res: Response) => {
+  const {postid, userid} = req.params;
+  let result;
+
+  try {
+    result = await User.findOneAndUpdate({
+          "images.id": postid
+        },
+        {
+          $pull: {
+            "images.$[images].likes": userid
+          }
+        },
+        {
+          arrayFilters: [
+            {
+              "images.id": postid
+            }
+          ], new: true
+        })
+  } catch (err) {
+    res.status(400).json({
+      message: "Error unliking post",
+      error: err,
+    });
+  }
+
+  res.status(200).json({
+    message: "Successfully disliked post",
+    data: result.images,
+  });
+
+}

--- a/server/models/user.model.ts
+++ b/server/models/user.model.ts
@@ -40,7 +40,7 @@ const userSchema = new mongoose.Schema(
             maxlength: 50
         },
         images: {
-          type: [],
+            type: [{id: String, url: String, description: String, likes: []}],
         },
         resetPasswordToken: String,
         resetPasswordExpire: Date,

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import {resetPassword, forgotPassword, loginUser, registerUser} from "./controllers/authControllers";
 import {getUser, getAllUsers, editUser} from "./controllers/userControllers";
-import { uploadImage} from "./controllers/imageController";
+import {likePost, unlikePost, uploadImage} from "./controllers/imageController";
 
 import { protect } from "./middleware/auth";
 
@@ -32,5 +32,12 @@ router.post("/api/:userid/images", uploadImage);
 
 router.get("/api/users", getAllUsers);
 router.get("/api/users/:id", getUser);
+
+/**
+ * LIKE ENDPOINTS
+ */
+
+router.put("/api/posts/:postid/likes/:userid", likePost)
+router.delete("/api/posts/:postid/likes/:userid", unlikePost)
 
 export default router;

--- a/server/router.ts
+++ b/server/router.ts
@@ -12,7 +12,7 @@ const router = express.Router();
  * AUTHENTICATION ENDPOINTS
  */
 
-router.get("/api/users/:id", getUser)
+
 router.post("/api/users/register", registerUser);
 router.post("/api/users/login", loginUser);
 router.post("/api/users/forgot-password", forgotPassword);


### PR DESCRIPTION
- Updated mongoose schema to include a likes array associated with each image uploaded.
- Implemented 2 endpoints to like/unlike post. 
- Added userid to redux slice and userData.
- Tested with postman.

When a user clicks the heart icon on a post, a request with the postid and the userid (of the user liking the post) is sent to the backend in the URL parameters. It can be determined if the action is a like/unlike based off if the userid is included in the likes array (accessed through the imageData). The number of likes can also be determined by the length of the likes array. Upon a successful like/unlike the backend responds with the update image data, and then the image data is set on the frontend. 

By using $addToSet in the like query, you can make sure that the put endpoint is idempotent and a user will never be able to vote multiple times even if the frontend allowed it.


https://user-images.githubusercontent.com/83941101/179391411-7c884fd7-0154-4063-876a-5988fbf910e3.mp4



